### PR TITLE
Bulk (de)activation

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		198B27A5141D978703733A87FA1E773A /* Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14ED86088CE0644078A9F4AF753B842C /* Constraints.swift */; };
 		21855F66DA09648C3C8C43D4F2F7AD76 /* Shortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B113BAA25CAE75F9B22CAD888896AF7 /* Shortcuts.swift */; };
 		2FD742CE6CABB76E4062228B8C6BD7EF /* constrain-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BB622EF60499A12E63036F7DF3DD7D90 /* constrain-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EB0E434242C014000244983 /* Modification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB0E433242C014000244983 /* Modification.swift */; };
+		4EB0E436242C01DF00244983 /* BulkOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB0E435242C01DF00244983 /* BulkOperations.swift */; };
 		7A1794CE4B93FB667A35563AEC5FAD43 /* AspectRatio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB1BB772E96F3F60BD7051503878F25 /* AspectRatio.swift */; };
 		7BF251ACCDA39CD4AA2E396EF339F1B3 /* Pods-constrain_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 028E49C8D45541F4883B47C66230914B /* Pods-constrain_Tests-dummy.m */; };
 		9AEB5098CFC540C1D3CE4BC05FF16E5C /* constrain-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E3B1A8DB7DC8A3CC0FF1F1CAB705F803 /* constrain-dummy.m */; };
@@ -42,6 +44,8 @@
 		35BC50A3EA8B30992BDF7DB6F68B1907 /* Pods-constrain_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-constrain_Tests-frameworks.sh"; sourceTree = "<group>"; };
 		3B113BAA25CAE75F9B22CAD888896AF7 /* Shortcuts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Shortcuts.swift; path = constrain/Classes/Shortcuts.swift; sourceTree = "<group>"; };
 		45922825A1107BA029AFA1CC887F0AA8 /* BaseTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BaseTypes.swift; path = constrain/Classes/BaseTypes.swift; sourceTree = "<group>"; };
+		4EB0E433242C014000244983 /* Modification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Modification.swift; path = constrain/Classes/Modification.swift; sourceTree = "<group>"; };
+		4EB0E435242C01DF00244983 /* BulkOperations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BulkOperations.swift; path = constrain/Classes/BulkOperations.swift; sourceTree = "<group>"; };
 		5DACBAF6C9C1EB1EBE329E4EE0C93A9C /* SafeArea.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SafeArea.swift; path = constrain/Classes/SafeArea.swift; sourceTree = "<group>"; };
 		6FB1BB772E96F3F60BD7051503878F25 /* AspectRatio.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AspectRatio.swift; path = constrain/Classes/AspectRatio.swift; sourceTree = "<group>"; };
 		9AC39245BAE566E3EFEEF485FDB878EA /* constrain-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "constrain-prefix.pch"; sourceTree = "<group>"; };
@@ -127,6 +131,8 @@
 				6FB1BB772E96F3F60BD7051503878F25 /* AspectRatio.swift */,
 				45922825A1107BA029AFA1CC887F0AA8 /* BaseTypes.swift */,
 				14ED86088CE0644078A9F4AF753B842C /* Constraints.swift */,
+				4EB0E433242C014000244983 /* Modification.swift */,
+				4EB0E435242C01DF00244983 /* BulkOperations.swift */,
 				A9FF33051E6BEB4735334964A2C14D25 /* Extensions.swift */,
 				5DACBAF6C9C1EB1EBE329E4EE0C93A9C /* SafeArea.swift */,
 				3B113BAA25CAE75F9B22CAD888896AF7 /* Shortcuts.swift */,
@@ -302,8 +308,10 @@
 				7A1794CE4B93FB667A35563AEC5FAD43 /* AspectRatio.swift in Sources */,
 				ADA6F99CE590ADAD4719AB72AC707DFC /* BaseTypes.swift in Sources */,
 				9AEB5098CFC540C1D3CE4BC05FF16E5C /* constrain-dummy.m in Sources */,
+				4EB0E434242C014000244983 /* Modification.swift in Sources */,
 				198B27A5141D978703733A87FA1E773A /* Constraints.swift in Sources */,
 				ED931D7D71307CE75B3E42448B67EB37 /* Extensions.swift in Sources */,
+				4EB0E436242C01DF00244983 /* BulkOperations.swift in Sources */,
 				F3DE7D5141CEEE4B7DCDF239BC490F63 /* SafeArea.swift in Sources */,
 				21855F66DA09648C3C8C43D4F2F7AD76 /* Shortcuts.swift in Sources */,
 			);

--- a/constrain/Classes/AspectRatio.swift
+++ b/constrain/Classes/AspectRatio.swift
@@ -27,7 +27,7 @@ public extension Constraints {
 
 public extension UIImage {
     /// may return NaN, but I decided this is preferable to Nil
-    /// constrain.aspectRatio() checks .isFinite before setting to avoid crash
+    /// constrain.aspectRatio() checks for `.isFinite` before setting to avoid crash
     var aspectRatio: CGFloat {
         return size.width/size.height
     }

--- a/constrain/Classes/BaseTypes.swift
+++ b/constrain/Classes/BaseTypes.swift
@@ -90,7 +90,7 @@ public extension Constraints {
 
 // Height and width stuff
 public extension Constraints {
-    /// Apply the height constraint of a view
+    /// Set the height constraint to a constant
     @discardableResult
     func height(_ constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
         guard let view = view else {
@@ -110,7 +110,7 @@ public extension Constraints {
         return applyAnchorConstraint(anchor1: view.heightAnchor, anchor2: anchor, identifier: .height, constant: constant, relationship: relationship, priority: priority)
     }
     
-    /// Apply the width constraint of a view
+    /// Set the width constraint to a constant
     @discardableResult
     func width(_ constant: CGFloat = 0.0, by relationship: Relationship = .equal, priority: UILayoutPriority = .required) -> Constraints {
         guard let view = view else {

--- a/constrain/Classes/BulkOperations.swift
+++ b/constrain/Classes/BulkOperations.swift
@@ -31,4 +31,13 @@ public extension Constraints {
         return isActive ? deactivate() : activate()
     }
     
+    @discardableResult
+    func clearSet() -> Self {
+        deactivate() // this also removes them from the view
+        allConstraints = []
+        constraints = [:]
+        isActive = true
+        return self
+    }
+    
 }

--- a/constrain/Classes/BulkOperations.swift
+++ b/constrain/Classes/BulkOperations.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-public typealias ConstraintSet = [NSLayoutConstraint]
-
 // bulk activation/deactivation
 public extension Constraints {
     

--- a/constrain/Classes/BulkOperations.swift
+++ b/constrain/Classes/BulkOperations.swift
@@ -10,24 +10,24 @@ import Foundation
 public typealias ConstraintSet = [NSLayoutConstraint]
 
 // bulk activation/deactivation
-extension Constraints {
+public extension Constraints {
     
     @discardableResult
-    public func activate() -> Self {
+    func activate() -> Self {
         NSLayoutConstraint.activate(allConstraints)
         isActive = true
         return self
     }
     
     @discardableResult
-    public func deactivate() -> Self {
+    func deactivate() -> Self {
         NSLayoutConstraint.deactivate(allConstraints)
         isActive = false
         return self
     }
     
     @discardableResult
-    public func toggle() -> Self {
+    func toggle() -> Self {
         return isActive ? deactivate() : activate()
     }
     

--- a/constrain/Classes/BulkOperations.swift
+++ b/constrain/Classes/BulkOperations.swift
@@ -1,0 +1,34 @@
+//
+//  BulkOperations.swift
+//  constrain
+//
+//  Created by New Greg on 3/25/20.
+//
+
+import Foundation
+
+public typealias ConstraintSet = [NSLayoutConstraint]
+
+// bulk activation/deactivation
+extension Constraints {
+    
+    @discardableResult
+    public func activate() -> Self {
+        NSLayoutConstraint.activate(allConstraints)
+        isActive = true
+        return self
+    }
+    
+    @discardableResult
+    public func deactivate() -> Self {
+        NSLayoutConstraint.deactivate(allConstraints)
+        isActive = false
+        return self
+    }
+    
+    @discardableResult
+    public func toggle() -> Self {
+        return isActive ? deactivate() : activate()
+    }
+    
+}

--- a/constrain/Classes/BulkOperations.swift
+++ b/constrain/Classes/BulkOperations.swift
@@ -30,7 +30,7 @@ public extension Constraints {
     }
     
     @discardableResult
-    func clearSet() -> Self {
+    func clearSaved() -> Self {
         deactivate() // this also removes them from the view
         allConstraints = []
         constraints = [:]

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -4,27 +4,7 @@
 
 import UIKit
 
-public enum ConstraintIdentifier: String {
-    case top = ".top"
-    case leading = ".leading"
-    case trailing = ".trailing"
-    case bottom = ".bottom"
-    case topSafe = ".topSafe"
-    case bottomSafe = ".bottomSafe"
-    case height = ".height"
-    case width = ".width"
-    case centerX = ".centerX"
-    case centerY = ".centerY"
-    case aspectRatio = ".aspectRatio"
-
-    // Not actually constraints:
-    case cornerRadius = ".cornerRadius"
-    case size = ".size" // size combines .width and .height
-}
-
 public typealias Relationship = NSLayoutConstraint.Relation
-
-public typealias ConstraintSet = [NSLayoutConstraint]
 
 /// Constraints is a container of layout constraints for a UIView. It has convenience methods for creating and retrieving constraints.
 /// For improved readability, all methods can be chained.
@@ -134,75 +114,4 @@ extension Constraints {
         allConstraints.append(constraint)
         latestConstraint = constraint
     }
-}
-
-extension Constraints {
-    
-    /// When storing a reference to a Constraints instance this method allows to retrieve a respective constraint.
-    public func layoutConstraintWithIdentifier(_ identifier: ConstraintIdentifier) -> NSLayoutConstraint? {
-        return constraints[identifier]
-    }
-    
-    /// When storing a reference to a Constraints instance this method allows to set the constant of a respective constraint.
-    public func setConstant(_ constant: CGFloat, forIdentifier identifier: ConstraintIdentifier) {
-        layoutConstraintWithIdentifier(identifier)?.constant = constant
-    }
-
-    @discardableResult
-    public func update(_ identifier: ConstraintIdentifier, to constant: CGFloat) -> Self {
-        // constrain will start to support setting and updating of view propperties that are not actually NSLayoutConstraints. We have to treat them slightly differently.
-        switch identifier {
-        case .cornerRadius:
-            cornerRadius(constant)
-        case .size:
-            setConstant(constant, forIdentifier: .width)
-            setConstant(constant, forIdentifier: .height)
-        default:
-            setConstant(constant, forIdentifier: identifier)
-        }
-        return self
-    }
-
-    @discardableResult
-    public func cornerRadius(_ value: CGFloat) -> Self {
-        view?.layer.cornerRadius = value
-        return self
-    }
-    
-}
-    
-extension Constraints {
-    
-    @discardableResult
-    public func refresh() -> Self {
-        view?.setNeedsLayout()
-        view?.layoutIfNeeded()
-        return self
-    }
-    
-}
-
-
-// bulk activation/deactivation
-extension Constraints {
-    
-    @discardableResult
-    public func activate() -> Self {
-        NSLayoutConstraint.activate(allConstraints)
-        isActive = true
-        return self
-    }
-    
-    @discardableResult
-    public func deactivate() -> Self {
-        NSLayoutConstraint.deactivate(allConstraints)
-        isActive = false
-        return self
-    }
-    
-    @discardableResult
-    public func toggle() -> Self {
-        return isActive ? deactivate() : activate()
-    }
-    
 }

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -147,7 +147,7 @@ extension Constraints {
 
     @discardableResult
     public func update(_ identifier: ConstraintIdentifier, to constant: CGFloat) -> Self {
-        // constrain wills tart to support setting and updating of view propperties that are not actually NSLayoutConstraints. We have to treat them slightly differently.
+        // constrain will start to support setting and updating of view propperties that are not actually NSLayoutConstraints. We have to treat them slightly differently.
         switch identifier {
         case .cornerRadius:
             cornerRadius(constant)

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -173,18 +173,21 @@ extension Constraints {
         return self
     }
     
+    @discardableResult
     public func activate() -> Self {
         NSLayoutConstraint.activate(allConstraints)
         isActive = true
         return self
     }
     
+    @discardableResult
     public func deactivate() -> Self {
         NSLayoutConstraint.deactivate(allConstraints)
         isActive = false
         return self
     }
     
+    @discardableResult
     public func toggle() -> Self {
         return isActive ? deactivate() : activate()
     }

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -15,9 +15,9 @@ public class Constraints {
     
     internal weak var view: UIView?
     internal var viewName: String
-    private var constraints: [ConstraintIdentifier: NSLayoutConstraint] = [:]
-    private var allConstraints: ConstraintSet = []
-    private var isActive = true
+    internal var constraints: [ConstraintIdentifier: NSLayoutConstraint] = [:]
+    internal var allConstraints: ConstraintSet = []
+    internal var isActive = true
     
     public var latestConstraint: NSLayoutConstraint?
     

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -16,7 +16,7 @@ public class Constraints {
     internal weak var view: UIView?
     internal var viewName: String
     internal var constraints: [ConstraintIdentifier: NSLayoutConstraint] = [:]
-    internal var allConstraints: ConstraintSet = []
+    internal var allConstraints: [NSLayoutConstraint] = []
     internal var isActive = true
     
     public var latestConstraint: NSLayoutConstraint?

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -40,9 +40,6 @@ public class Constraints {
     private var isActive = true
     
     public var latestConstraint: NSLayoutConstraint?
-    // Not implemented yet
-    @available(*, unavailable)
-    public var latestConstraints: ConstraintSet?
     
     internal init(view: UIView, name: String? = nil) {
         self.view = view

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -37,6 +37,7 @@ public class Constraints {
     internal var viewName: String
     private var constraints: [ConstraintIdentifier: NSLayoutConstraint] = [:]
     private var allConstraints: ConstraintSet = []
+    private var isActive = true
     
     public var latestConstraint: NSLayoutConstraint?
     // Not implemented yet
@@ -177,12 +178,18 @@ extension Constraints {
     
     public func activate() -> Self {
         NSLayoutConstraint.activate(allConstraints)
+        isActive = true
         return self
     }
     
     public func deactivate() -> Self {
         NSLayoutConstraint.deactivate(allConstraints)
+        isActive = false
         return self
+    }
+    
+    public func toggle() -> Self {
+        return isActive ? deactivate() : activate()
     }
     
 }

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -175,4 +175,14 @@ extension Constraints {
         return self
     }
     
+    public func activate() -> Self {
+        NSLayoutConstraint.activate(allConstraints)
+        return self
+    }
+    
+    public func deactivate() -> Self {
+        NSLayoutConstraint.deactivate(allConstraints)
+        return self
+    }
+    
 }

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -108,7 +108,7 @@ extension Constraints {
     
     fileprivate func finalizeConstraint(_ constraint: NSLayoutConstraint, _ identifier: ConstraintIdentifier) {
         view?.translatesAutoresizingMaskIntoConstraints = false
-        constraint.isActive = true
+        constraint.isActive = isActive
         constraint.identifier = viewName + identifier.rawValue
         constraints[identifier] = constraint
         allConstraints.append(constraint)

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -134,6 +134,9 @@ extension Constraints {
         allConstraints.append(constraint)
         latestConstraint = constraint
     }
+}
+
+extension Constraints {
     
     /// When storing a reference to a Constraints instance this method allows to retrieve a respective constraint.
     public func layoutConstraintWithIdentifier(_ identifier: ConstraintIdentifier) -> NSLayoutConstraint? {
@@ -165,13 +168,23 @@ extension Constraints {
         view?.layer.cornerRadius = value
         return self
     }
-
+    
+}
+    
+extension Constraints {
+    
     @discardableResult
     public func refresh() -> Self {
         view?.setNeedsLayout()
         view?.layoutIfNeeded()
         return self
     }
+    
+}
+
+
+// bulk activation/deactivation
+extension Constraints {
     
     @discardableResult
     public func activate() -> Self {

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -36,6 +36,7 @@ public class Constraints {
     internal weak var view: UIView?
     internal var viewName: String
     private var constraints: [ConstraintIdentifier: NSLayoutConstraint] = [:]
+    private var allConstraints: ConstraintSet = []
     
     public var latestConstraint: NSLayoutConstraint?
     // Not implemented yet
@@ -131,7 +132,8 @@ extension Constraints {
         view?.translatesAutoresizingMaskIntoConstraints = false
         constraint.isActive = true
         constraint.identifier = viewName + identifier.rawValue
-        constraints[identifier] = constraint // TODO: deactivate any existing before overwriting, or allow more than one of same identifier
+        constraints[identifier] = constraint
+        allConstraints.append(constraint)
         latestConstraint = constraint
     }
     

--- a/constrain/Classes/Constraints.swift
+++ b/constrain/Classes/Constraints.swift
@@ -27,7 +27,7 @@ public typealias Relationship = NSLayoutConstraint.Relation
 public typealias ConstraintSet = [NSLayoutConstraint]
 
 /// Constraints is a container of layout constraints for a UIView. It has convenience methods for creating and retrieving constraints.
-/// For improved readability constraint-creation methods can be chained.
+/// For improved readability, all methods can be chained.
 /// Constraints are active on creation
 /// Most methods allow the omission of an anchor or view to be passed in.
 /// The superview is used when no view is passed in and the superview's respective anchor is used when the anchor is omitted.

--- a/constrain/Classes/Extensions.swift
+++ b/constrain/Classes/Extensions.swift
@@ -86,3 +86,18 @@ public extension UIView {
     }
     
 }
+
+extension UIView {
+    public func refresh() {
+        setNeedsLayout()
+        layoutIfNeeded()
+    }
+}
+
+extension Constraints {
+    @discardableResult
+    public func refresh() -> Self {
+        view?.refresh()
+        return self
+    }
+}

--- a/constrain/Classes/Modification.swift
+++ b/constrain/Classes/Modification.swift
@@ -1,0 +1,59 @@
+//
+//  Modification.swift
+//  constrain
+//
+//  Created by Greg on 3/25/20.
+//
+
+public enum ConstraintIdentifier: String {
+    case top = ".top"
+    case leading = ".leading"
+    case trailing = ".trailing"
+    case bottom = ".bottom"
+    case topSafe = ".topSafe"
+    case bottomSafe = ".bottomSafe"
+    case height = ".height"
+    case width = ".width"
+    case centerX = ".centerX"
+    case centerY = ".centerY"
+    case aspectRatio = ".aspectRatio"
+
+    // Not actually constraints:
+    case cornerRadius = ".cornerRadius"
+    case size = ".size" // size combines .width and .height
+}
+
+extension Constraints {
+    
+    /// When storing a reference to a Constraints instance this method allows to retrieve a respective constraint.
+    public func layoutConstraintWithIdentifier(_ identifier: ConstraintIdentifier) -> NSLayoutConstraint? {
+        return constraints[identifier]
+    }
+    
+    /// When storing a reference to a Constraints instance this method allows to set the constant of a respective constraint.
+    public func setConstant(_ constant: CGFloat, forIdentifier identifier: ConstraintIdentifier) {
+        layoutConstraintWithIdentifier(identifier)?.constant = constant
+    }
+
+    @discardableResult
+    public func update(_ identifier: ConstraintIdentifier, to constant: CGFloat) -> Self {
+        // constrain will start to support setting and updating of view propperties that are not actually NSLayoutConstraints. We have to treat them slightly differently.
+        switch identifier {
+        case .cornerRadius:
+            cornerRadius(constant)
+        case .size:
+            setConstant(constant, forIdentifier: .width)
+            setConstant(constant, forIdentifier: .height)
+        default:
+            setConstant(constant, forIdentifier: identifier)
+        }
+        return self
+    }
+
+    @discardableResult
+    public func cornerRadius(_ value: CGFloat) -> Self {
+        view?.layer.cornerRadius = value
+        return self
+    }
+    
+}


### PR DESCRIPTION
 - add methods to quickly activate or inactivate all constraints in the instance
    - added property to store all constraints, independently of identifier to prevent overwriting
 - add method to toggle activation of all constraints
    - added property to track activation state
 - reorganized a bit
 - removed latestConstraints, since it was unfinished and this bulk stuff kinda covers that.
 - added method to remove all constraints from the class completely

Check out this set of commits to see the changes with reorganization excluded:
https://github.com/anconaesselmann/constrain/pull/4/files/4a61be8848122f59546a3c0fefa542e68f19872b
I can also break the reorg into a separate PR if preferred